### PR TITLE
Upgrade mongodb to 4.0.6

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,3 +18,8 @@ Finally, BioThings Studio comes in different flavors, to facilitate contribution
 - *Studio for MyVariant.info* : http://biothings-containers.s3-website-us-west-2.amazonaws.com/biothings_studio/studio4myvariant_unstable.docker (unstable)
 
 - *Studio for MyChem.info* : http://biothings-containers.s3-website-us-west-2.amazonaws.com/biothings_studio/studio4mychem_unstable.docker (unstable)
+
+## Build Images
+
+Please see the README.md file in the 'docker' directory.
+

--- a/docker/README.md
+++ b/docker/README.md
@@ -6,3 +6,12 @@ docker run --rm --name studio -p 8000:8000 -p 8080:8080 -p 7022:7022 -p 7080:708
 # or, using Makefile
 make biothings_studio       # build image
 make biothings_studio save  # save image
+
+## Other Targets:
+
+prerequisite:  docker, make
+
+- `make studio4mygene`
+- `make studio4myvariant`
+- `make studio4mychem`
+

--- a/docker/ansible_playbook/configure.yml
+++ b/docker/ansible_playbook/configure.yml
@@ -73,15 +73,35 @@
 ##################################################
 
 - name: Add mongodb public signing key
-  apt_key: keyserver=keyserver.ubuntu.com id=EA312927
+  apt_key: keyserver=keyserver.ubuntu.com id=9DA31620334BD75D9DCB49F368818C72E52529D4
   become: yes
 
 - name: Add mongodb repository to apt sources
   apt_repository: repo={{ software.common_configurations.mongodb.apt_repository }}
   become: yes
 
-- name: Install mongodb
+- name: Install libcurl3
+  apt: name=libcurl3
+  become: yes
+
+- name: Install mongodb (server)
+  apt: name=mongodb-org-server={{ software.common_configurations.mongodb.version }}
+  become: yes
+
+- name: Install mongodb (org)
   apt: name=mongodb-org={{ software.common_configurations.mongodb.version }}
+  become: yes
+
+- name: Install mongodb (shell)
+  apt: name=mongodb-org-shell={{ software.common_configurations.mongodb.version }}
+  become: yes
+
+- name: Install mongodb (mongos)
+  apt: name=mongodb-org-mongos={{ software.common_configurations.mongodb.version }}
+  become: yes
+
+- name: Install mongodb (tools)
+  apt: name=mongodb-org-tools={{ software.common_configurations.mongodb.version }}
   become: yes
 
 - name: template out mongod.conf

--- a/docker/ansible_playbook/vars/biothings_studio.yml
+++ b/docker/ansible_playbook/vars/biothings_studio.yml
@@ -34,8 +34,8 @@ software:
     cerebro:
       version: "0.8.1"
     mongodb:
-      version: "3.2.18"
-      apt_repository: "deb http://repo.mongodb.org/apt/ubuntu xenial/mongodb-org/3.2 multiverse"
+      version: "4.0.6"
+      apt_repository: "deb http://repo.mongodb.org/apt/ubuntu xenial/mongodb-org/4.0 multiverse"
       port: 27017
       bindip: "127.0.0.1"
       oplogsizemb: 50


### PR DESCRIPTION
These changes upgrade MongoDB from version 3.2.18 up to 4.0.6.  The docker image 'studio4mychem' was created and the biothings.api hub was started.  The biothings web page was used to 'dump' and upload 'unii'.  A release was created then an API was created and started.  Data was returned using the API via 'curl'.

Hopefully this helps move development along.