### PR TITLE
Emit change_build event after successful build deletion

### DIFF
--- a/webapp/src/Api.vue
+++ b/webapp/src/Api.vue
@@ -102,8 +102,8 @@
 
 
       <div class="ui icon buttons right floated mini">
-        <button class="ui button delete-btn" data-tooltip="Delete API">
-          <i class="trash icon" :data-api_id="api._id" @click="deleteAPI($event)"></i>
+        <button class="ui button delete-btn" data-tooltip="Delete API" :data-api_id="api._id" @click="deleteAPI($event)">
+          <i class="trash icon"></i>
         </button>
       </div>
     </div>
@@ -210,7 +210,7 @@ export default {
     },
     deleteAPI: function (event) {
       console.log(event)
-      var api_id = $(event.target).attr('data-api_id')
+      var api_id = $(event.currentTarget).attr('data-api_id')
       // filter Api component to open correct modal
       console.log(`${api_id} ${this.api._id}`)
       if (!api_id || api_id !== this.api._id) {

--- a/webapp/src/Build.vue
+++ b/webapp/src/Build.vue
@@ -74,13 +74,13 @@
                 </button>
             </div>
             <div class="ui icon buttons right floated mini">
-                <button class="ui button m-1 delete-btn" data-tooltip="Delete">
-                    <i class="trash icon" @click="deleteBuild()"></i>
+                <button class="ui button m-1 delete-btn" data-tooltip="Delete" @click="deleteBuild()">
+                    <i class="trash icon"></i>
                 </button>
             </div>
             <div class="ui icon buttons right floated mini" v-if="!build.archived">
-                <button class="ui button m-1" data-tooltip="Archive">
-                    <i :class="[build.archived ? 'archived' : '', 'archive icon']" @click="archiveBuild()"></i>
+                <button class="ui button m-1" data-tooltip="Archive" @click="archiveBuild()">
+                    <i :class="[build.archived ? 'archived' : '', 'archive icon']"></i>
                 </button>
             </div>
         </div>

--- a/webapp/src/Build.vue
+++ b/webapp/src/Build.vue
@@ -211,6 +211,7 @@ export default {
             axios.delete(axios.defaults.baseURL + `/build/${self.build._id}`)
               .then(response => {
                 console.log(response.data.result)
+                bus.$emit('change_build')
                 return true
               })
               .catch(err => {


### PR DESCRIPTION
This pull request improves the handling of delete and archive button actions in the `Api.vue` and `Build.vue` components. The main focus is on ensuring that click events are correctly captured and processed, and that UI updates are triggered after certain actions.

**Event handling and UI updates:**

* Moved the `@click` event listeners from the icon (`<i>`) elements to their parent button elements in both `Api.vue` and `Build.vue`, ensuring that the correct element receives the click event and the associated data attributes are accessible. [[1]](diffhunk://#diff-f16a3bec87c4f707dc4b0c474be014b4f66d8ddd143d2fa64f1abe7d534a4cedL105-R106) [[2]](diffhunk://#diff-f80bee197283d7a0c99af3d237416ed310f3e2dddcafe0414382f57af5175651L77-R83)
* Updated the `deleteAPI` method in `Api.vue` to use `event.currentTarget` instead of `event.target` for retrieving the `data-api_id`, making the code more robust and accurately targeting the button element.
* In `Build.vue`, after a successful build deletion, added an event emission (`bus.$emit('change_build')`) to notify other components of the change and trigger UI updates.

Closes #127 